### PR TITLE
Cmake update + flatpak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
 
 pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 pkg_check_modules(GTKSOURCEVIEWMM REQUIRED gtksourceviewmm-3.0)
-pkg_check_modules(LIBXMLPP REQUIRED libxml++-2.6)
+pkg_check_modules(LIBXMLPP REQUIRED libxml++-3.0)
 pkg_check_modules(LIBCURL REQUIRED libcurl)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -D_GLIBCXX_USE_NANOSLEEP -DPACKAGE=emilpro -DPACKAGE_VERSION=1 -pthread")
@@ -168,3 +168,5 @@ target_link_libraries(emilpro
 target_link_libraries(tools/squash-instruction-models
 	${BASE_LIBS}
 	)
+
+install(TARGETS emilpro RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
 
 pkg_check_modules(GTKMM REQUIRED gtkmm-3.0)
 pkg_check_modules(GTKSOURCEVIEWMM REQUIRED gtksourceviewmm-3.0)
-pkg_check_modules(LIBXMLPP REQUIRED libxml++-3.0)
+pkg_check_modules(LIBXMLPP REQUIRED libxml++-2.6)
 pkg_check_modules(LIBCURL REQUIRED libcurl)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -D_GLIBCXX_USE_NANOSLEEP -DPACKAGE=emilpro -DPACKAGE_VERSION=1 -pthread")

--- a/flatpak.json
+++ b/flatpak.json
@@ -1,0 +1,103 @@
+{
+    "app-id": "de.simonkagstrom.emilpro",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.9",
+    "sdk": "org.kde.Sdk",
+    "command": "emilpro",
+    "finish-args": [
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=host",
+        "--share=network"
+    ],
+    "modules": [
+        {
+            "name": "mm-common",
+            "cleanup": [
+                "/"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/mm-common/0.9/mm-common-0.9.9.tar.xz",
+                    "sha256": "9d00bc77e77794e0bd2ae68132c4b4136aa115d255e34b310f7449b29db50b7a"
+                }
+            ]
+        },
+        {
+            "name": "sigc++",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.9/libsigc++-2.9.3.tar.xz",
+                    "sha256": "0bf9b301ad6198c550986c51150a646df198e8d1d235270c16486b0dda30097f"
+                }
+            ]
+        },
+        {
+            "name": "glibmm",
+            "config-opts": [
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.47/glibmm-2.47.92.tar.xz",
+                    "sha256": "47cfcd960cbd78e1e960a04aa650227e7ce57874121f0f014140d3e40c928900"
+                }
+            ]
+        },
+        {
+            "name": "libcapstone",
+            "config-opts": "-DCMAKE_BUILD_TYPE=Release",
+            "build-options": {
+                "cxxflags": "-O2 -g -std=c++11"
+            },
+            "cmake": true,
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/aquynh/capstone/archive/3.0.5-rc2.tar.gz",
+                    "sha256": "587c092454ad59137686529f3c008c265cc6d427a85d5d2e8f6a902b72d215b3"
+                }
+            ]
+        },
+        {
+            "name": "libxml++",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.acc.umu.se/pub/GNOME/sources/libxml++/3.0/libxml++-3.0.1.tar.xz",
+                    "sha256": "19dc8d21751806c015179bc0b83f978e65c878724501bfc0b6c1bcead29971a6"
+                }
+            ]
+        },
+        {
+            "name": "emilpro",
+            "cmake": true,
+            "builddir": true,
+            "config-opts": "-DCMAKE_BUILD_TYPE=Release",
+            "build-options": {
+                "build-args": [
+                    "--share=network"
+                ]
+            },
+            "subdir": "src/qt/",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/SimonKagstrom/emilpro",
+                    "branch": "master"
+                },
+                {
+                    "type": "patch",
+                    "path": "libxmlversion.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/flatpak.json
+++ b/flatpak.json
@@ -71,8 +71,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.acc.umu.se/pub/GNOME/sources/libxml++/3.0/libxml++-3.0.1.tar.xz",
-                    "sha256": "19dc8d21751806c015179bc0b83f978e65c878724501bfc0b6c1bcead29971a6"
+                    "url": "http://ftp.acc.umu.se/pub/GNOME/sources/libxml++/2.40/libxml++-2.40.1.tar.xz",
+                    "sha256": "4ad4abdd3258874f61c2e2a41d08e9930677976d303653cd1670d3e9f35463e9"
                 }
             ]
         },
@@ -92,10 +92,6 @@
                     "type": "git",
                     "url": "https://github.com/SimonKagstrom/emilpro",
                     "branch": "master"
-                },
-                {
-                    "type": "patch",
-                    "path": "libxmlversion.patch"
                 }
             ]
         }

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
                         ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-pkg_check_modules(LIBXMLPP REQUIRED libxml++-3.0)
+pkg_check_modules(LIBXMLPP REQUIRED libxml++-2.6)
 pkg_check_modules(LIBCURL REQUIRED libcurl)
 
 set (CMAKE_CXX_FLAGS "-std=c++0x -g -O0 -Wall -D_GLIBCXX_USE_NANOSLEEP -DPACKAGE=emilpro -DPACKAGE_VERSION=1 ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS} -pthread")

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set (CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}
                         ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-pkg_check_modules(LIBXMLPP REQUIRED libxml++-2.6)
+pkg_check_modules(LIBXMLPP REQUIRED libxml++-3.0)
 pkg_check_modules(LIBCURL REQUIRED libcurl)
 
 set (CMAKE_CXX_FLAGS "-std=c++0x -g -O0 -Wall -D_GLIBCXX_USE_NANOSLEEP -DPACKAGE=emilpro -DPACKAGE_VERSION=1 ${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS} -pthread")
@@ -176,3 +176,5 @@ target_link_libraries(emilpro
 target_link_libraries(tools/squash-instruction-models
 	${BASE_LIBS}
 	)
+
+install(TARGETS emilpro RUNTIME DESTINATION bin)


### PR DESCRIPTION
As mentioned in the #56, I am not sure if the version number of libxml is intentional or can be changed generally. Maybe we could also try to define a version "greater than" but I am not sure how...
At least it seems to build + work with this version of libxml.

The flatpak works fine, too. For submission to e.g. FlatHub, it would need a desktop file and an application icon.

Cheers,

Wolf